### PR TITLE
Check limit before requesting next_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.9.2
+ - Added check whether results pulled is equal to the limit before requesting next_url to avoid rate limit error in high volume environments
 ## 0.9.1
   - Updates dependencies to standard
 ## 0.9.0


### PR DESCRIPTION
To avoid hitting the rate limit in high volume instances which always seems to have more records, check whether a run pulled the configured limit. If so, continue with the next_url. If we did not pull the record limit, save the next_url and end until the next scheduled run.